### PR TITLE
fix svhn label mismatch (label 10 -> label 0)

### DIFF
--- a/datasets/da/digit5.py
+++ b/datasets/da/digit5.py
@@ -55,10 +55,12 @@ def load_svhn(data_dir, raw_data_dir):
     train = loadmat(osp.join(raw_data_dir, "svhn_train_32x32.mat"))
     train_data = train["X"].transpose(3, 0, 1, 2)
     train_label = train["y"][:, 0]
+    train_label[train_label == 10] = 0
 
     test = loadmat(osp.join(raw_data_dir, "svhn_test_32x32.mat"))
     test_data = test["X"].transpose(3, 0, 1, 2)
     test_label = test["y"][:, 0]
+    test_label[test_label == 10] = 0
 
     return train_data, test_data, train_label, test_label
 


### PR DESCRIPTION
Hi, I found that the default label setting of the SVHN dataset gives label 10 to digit 0, while in other datasets of Digit-Five, digit 0 is assigned label 0. I think this PR is a bug fix.

PyTorch also has a similar description in their document about [SVHN dataset](https://pytorch.org/vision/stable/generated/torchvision.datasets.SVHN.html#torchvision.datasets.SVHN):

> [SVHN](http://ufldl.stanford.edu/housenumbers/) Dataset. Note: The SVHN dataset assigns the label 10 to the digit 0. However, in this Dataset, we assign the label 0 to the digit 0 to be compatible with PyTorch loss functions which expect the class labels to be in the range [0, C-1]