### PR TITLE
change Image.BILINEAR to InterpolationMode.BILINEAR

### DIFF
--- a/dassl/data/data_manager.py
+++ b/dassl/data/data_manager.py
@@ -9,11 +9,7 @@ from .datasets import build_dataset
 from .samplers import build_sampler
 from .transforms import build_transform
 
-INTERPOLATION_MODES = {
-    "bilinear": Image.BILINEAR,
-    "bicubic": Image.BICUBIC,
-    "nearest": Image.NEAREST,
-}
+from .transforms import INTERPOLATION_MODES
 
 
 def build_data_loader(

--- a/dassl/data/transforms/__init__.py
+++ b/dassl/data/transforms/__init__.py
@@ -1,1 +1,1 @@
-from .transforms import build_transform
+from .transforms import build_transform, INTERPOLATION_MODES

--- a/dassl/data/transforms/transforms.py
+++ b/dassl/data/transforms/transforms.py
@@ -8,6 +8,8 @@ from torchvision.transforms import (
     RandomHorizontalFlip
 )
 
+from torchvision.transforms.functional import InterpolationMode
+
 from .autoaugment import SVHNPolicy, CIFAR10Policy, ImageNetPolicy
 from .randaugment import RandAugment, RandAugment2, RandAugmentFixMatch
 
@@ -33,9 +35,9 @@ AVAI_CHOICES = [
 ]
 
 INTERPOLATION_MODES = {
-    "bilinear": Image.BILINEAR,
-    "bicubic": Image.BICUBIC,
-    "nearest": Image.NEAREST,
+    "bilinear": InterpolationMode.BILINEAR,
+    "bicubic": InterpolationMode.BICUBIC,
+    "nearest": InterpolationMode.NEAREST,
 }
 
 
@@ -49,10 +51,10 @@ class Random2DTranslation:
         p (float, optional): probability that this operation takes place.
             Default is 0.5.
         interpolation (int, optional): desired interpolation. Default is
-            ``PIL.Image.BILINEAR``
+            ``torchvision.transforms.functional.InterpolationMode.BILINEAR``
     """
 
-    def __init__(self, height, width, p=0.5, interpolation=Image.BILINEAR):
+    def __init__(self, height, width, p=0.5, interpolation=InterpolationMode.BILINEAR):
         self.height = height
         self.width = width
         self.p = p


### PR DESCRIPTION
for python warnnings: /opt/conda/lib/python3.7/site-packages/torchvision/transforms/transforms.py:288: UserWarning: Argument interpolation should be of type InterpolationMode instead of int. Please, use InterpolationMode enum.

  "Argument interpolation should be of type InterpolationMode instead of int. "

Signed-off-by: siaimes <34199488+siaimes@users.noreply.github.com>